### PR TITLE
Make it easier to compile this from a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,16 @@ INCLUDES=-I$(HDF5_DIR)/include
 CFLAGS = $(DEBUG) -fPIC $(INCLUDES) -Wall
 #LIBS=-L$(HDF5_DIR)/lib -L$(MPI_DIR)/lib -lhdf5 -lz
 LIBS=-L$(HDF5_DIR)/lib -lhdf5 -lz
-DYNLDFLAGS = $(DEBUG) -dynamiclib -current_version 1.0 -fPIC $(LIBS)
+DYNLDFLAGS = -dynamiclib -current_version 1.0 
 LDFLAGS = $(DEBUG) $(LIBS)
 ARFLAGS = rs
 
 # Shared library VOL connector
+DYNEXT = dylib
 DYNSRC = H5VLprovnc.c
 DYNOBJ = $(DYNSRC:.c=.o)
-DYNLIB = libh5prov.dylib
-DYNDBG = libh5prov.dylib.dSYM
+DYNLIB = libh5prov.$(DYNEXT)
+DYNDBG = libh5prov.$(DYNEXT).dSYM
 
 # Testcase section
 EXSRC = vpicio_uni_h5.c
@@ -32,7 +33,7 @@ $(EXEXE): $(EXSRC) $(STATLIB) $(DYNLIB)
 	$(CC) $(CFLAGS) $^ -o $(EXEXE) $(LDFLAGS)
 
 $(DYNLIB): $(DYNSRC)
-	$(CC) $(CFLAGS) $(DYNLDFLAGS) $^ -o $@
+	$(CC) $(CFLAGS) $(DYNLDFLAGS) $(LIBS) $^ -o $@
 
 .PHONY: clean all
 clean:


### PR DESCRIPTION
A few changes to make it easier to compile from a script overriding some of the symbols with environment variables and using `make -e`
For example, I can now compile on linux using:
```
DYNLDFLAGS="-shared" CC=mpicc HDF5_DIR=/scratch/gdsjaar/seacas-async DYNEXT=so make -e
```
A simple `make` should still give the same behavior as before.  Note that `-fPIC` and `$(DEBUG)` are alreacy specified in `CFLAGS`, so don't need to be repeated.